### PR TITLE
Update --profile to --profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,18 @@ pip install yawsso
 - Do your per normal SSO login like so:
 ```commandline
 aws configure sso
-aws sso login --profile=dev
+aws sso login
 ```
 
-- To sync for `default` profile, just:
+- To sync for all profiles, just:
 ```commandline
 yawsso
 ```
 
-- To sync for named profile, do:
+- To sync for named profiles, do:
 ```commandline
-yawsso -p dev
+yawsso -p dev prod stage
+yawsso --profiles dev
 ```
 
 - Then, continue per normal with your daily tools. i.e. 

--- a/yawsso/cli.py
+++ b/yawsso/cli.py
@@ -217,4 +217,4 @@ def main():
 
         update_aws_cli_v1_credentials(profile_name, profile, credentials)
 
-        logger.info(f"Done syncing up AWS CLI v1 credentials using AWS CLI v2 SSO login session")
+        logger.info(f"Done syncing up AWS CLI v1 credentials using AWS CLI v2 SSO login session for " + str(profile_name))


### PR DESCRIPTION
I find, when working with an abundance of different accounts, often times I need to update multiple credentials at once, but perhaps not all of my credentials all the time. I also rarely want to use my default account.

I changed functionality so that without the "--profiles" flag, all profiles are synced with the creds file by default, but with the flag, one can specify what profiles they want to sync, to save time and limit extra creds sitting around. 

Example1: `yawsso #all profiles synced with creds file`
Example2: `yawsso --profiles prod stage #only specified profiles synced with creds file`

This is really up to the user-base, but I know my users prefer this type of functionality as an opt-out rather than opt-in feature. No worries if you prefer your workflow as is. 🖖 