### PR TITLE
Add exportvars feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ yawsso --default -p dev prod
     - `cw ls -p dev groups`
     - `awsbw -L -P dev` 
 
+- Or if you want a temporary copy-pasteable time-gated access token for an instance or external machine. Please use this feature with care since **environment variables used on shared systems can give unauthorized access to private resources**:
+
+```commandline
+yawsso -e
+export AWS_ACCESS_KEY_ID=ASIAFOOBARFOOBAR
+export AWS_SECRET_ACCESS_KEY=BAZBARBAZBAR
+export AWS_SESSION_TOKEN=LOREMIPSUMDOLOR
+```
+
 - To print help:
 ```commandline
 yawsso -h

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -291,13 +291,13 @@ class CLIUnitTests(TestCase):
     def test_sts_get_caller_identity_fail(self):
         when(cli).invoke(contains('aws sts get-caller-identity')).thenReturn((False, 'does-not-matter'))
         with self.assertRaises(SystemExit) as x:
-            cli.update_profile("dev", cli.read_config(self.config.name), "aws", false)
+            cli.update_profile("dev", cli.read_config(self.config.name), "aws", False)
         self.assertEqual(x.exception.code, 1)
 
     def test_sso_get_role_credentials_fail(self):
         when(cli).invoke(contains('aws sso get-role-credentials')).thenReturn((False, 'does-not-matter'))
         with self.assertRaises(SystemExit) as x:
-            cli.update_profile("dev", cli.read_config(self.config.name), "aws", false)
+            cli.update_profile("dev", cli.read_config(self.config.name), "aws", False)
         self.assertEqual(x.exception.code, 1)
 
     def test_aws_cli_version_fail(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -291,13 +291,13 @@ class CLIUnitTests(TestCase):
     def test_sts_get_caller_identity_fail(self):
         when(cli).invoke(contains('aws sts get-caller-identity')).thenReturn((False, 'does-not-matter'))
         with self.assertRaises(SystemExit) as x:
-            cli.update_profile("dev", cli.read_config(self.config.name), "aws")
+            cli.update_profile("dev", cli.read_config(self.config.name), "aws", false)
         self.assertEqual(x.exception.code, 1)
 
     def test_sso_get_role_credentials_fail(self):
         when(cli).invoke(contains('aws sso get-role-credentials')).thenReturn((False, 'does-not-matter'))
         with self.assertRaises(SystemExit) as x:
-            cli.update_profile("dev", cli.read_config(self.config.name), "aws")
+            cli.update_profile("dev", cli.read_config(self.config.name), "aws", false)
         self.assertEqual(x.exception.code, 1)
 
     def test_aws_cli_version_fail(self):


### PR DESCRIPTION
For quickly reusing tokens on arbitrary machines and instances one might be working on.

This is unsafe and dangerous, only use if you know what you are doing ;)