### PR TITLE
Added zulu format support for SSO cached login expiry

### DIFF
--- a/yawsso/__init__.py
+++ b/yawsso/__init__.py
@@ -1,2 +1,2 @@
 """yawsso cli package, version follow PEP440."""
-__version__ = VERSION = '0.6.0'  # pragma: no cover
+__version__ = VERSION = '0.6.1'  # pragma: no cover

--- a/yawsso/cli.py
+++ b/yawsso/cli.py
@@ -176,8 +176,10 @@ def write_config(path, config):
 
 
 def parse_sso_cached_login_expiry(cached_login):
-    datetime_format_in_sso_cached_login = "%Y-%m-%dT%H:%M:%SUTC"
-    expires_utc = datetime.strptime((cached_login["expiresAt"]), datetime_format_in_sso_cached_login)
+    # older versions of aws-cli might use non-standard format with `UTC` instead of `Z`
+    expires_at = cached_login["expiresAt"].replace('UTC', 'Z')
+    datetime_format_in_sso_cached_login = "%Y-%m-%dT%H:%M:%SZ"
+    expires_utc = datetime.strptime(expires_at, datetime_format_in_sso_cached_login)
     return expires_utc
 
 


### PR DESCRIPTION
* aws-cli/2.1.14 cached login expiresAt now use zulu format
* Applied fixes suggested in #42
* Bumped patch version `0.6.1`
