### PR TITLE
Only add --profile flag to aws sso command if profile passed

### DIFF
--- a/yawsso/cli.py
+++ b/yawsso/cli.py
@@ -487,7 +487,7 @@ def main():
                 else:
                     login_profile = args.profile
 
-            cmd_aws_sso_login = f"{cmd_aws_sso_login} --profile={login_profile}"
+                cmd_aws_sso_login = f"{cmd_aws_sso_login} --profile={login_profile}"
 
             logger.log(TRACE, f"Running command: `{cmd_aws_sso_login}`")
 


### PR DESCRIPTION
This allows `aws sso` to otherwise read the `AWS_PROFILE` var.

Note: the only change here is to nest the addition to `cmd_aws_sso_login` _inside_ the `if args.profile:` block.