### PR TITLE
Allow execution of the Python script when the region of one AWS account is different from sso_region.

### DIFF
--- a/yawsso/cli.py
+++ b/yawsso/cli.py
@@ -356,9 +356,6 @@ def update_profile(profile_name, config, new_profile_name=""):
         if not is_sso_profile(source_profile):
             logger.warning(f"Your source_profile is not an AWS SSO profile. Skip syncing profile `{profile_name}`")
             return
-        if profile['region'] != source_profile['sso_region']:
-            logger.warning(f"Region mismatch with source_profile AWS SSO region. Skip syncing profile `{profile_name}`")
-            return
         check_sso_cached_login_expires(source_profile_name, source_profile)
         eager_sync_source_profile(source_profile_name, source_profile)
         logger.log(TRACE, f"Fetching credentials using assume role for `{profile_name}`")


### PR DESCRIPTION
Hello @victorskl !

First of all thanks for your plugin  :-) 
I installed and use this script, login to SSO is woking fine but I always receive one message from the Terminal and I was confused with this reason:

> Region mismatch with source_profile AWS SSO region. Skip syncing profile

Some context --> I'm using SSO that I have configured in AWS eu-west-1 (Ireland) but I want to do login in other account in ap-southeast-1 (Singapore) using ROLE assumed.

I take a look inside the Python script and I know what happened, for some reason you put a condition, when the region of one AWS account is different from sso_region you will see the previous "Error message" I only remove this lines and it works for me.

Please, if you consider correct the change add to your branch and create new release.

############ COMMIT ############################################################################
Change the cli.py to allow the execution of the Python script when the region of one AWS account is different from sso_region.
################################################################################################
