### PR TITLE
fix: resolved problem with usage of source_profile and role_arn

### DIFF
--- a/yawsso/core.py
+++ b/yawsso/core.py
@@ -156,7 +156,7 @@ def fetch_credentials_with_assume_role(profile_name, profile):
     utc_now_ts = int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp())
     cmd_assume_role_cred = f"{aws_bin} sts assume-role " \
                            f"--output json " \
-                           f"--profile {profile_name} " \
+                           f"--profile {profile['source_profile']} " \
                            f"--role-arn {profile['role_arn']} " \
                            f"--role-session-name yawsso-session-{utc_now_ts} " \
                            f"--duration-seconds {duration_seconds} " \


### PR DESCRIPTION
- assume you have this setup: 
  ```
  [default] sso_account_id = 123 ...

  [profile assuming-profile]
  role_arn = arn:aws:iam::123123123:role/my-role 
  source_profile = default region = eu-central-1 
  output = text duration_seconds = 3600
  ```
- previously, yawsso used 'assuming-profile' as the profile when getting the credentials via sts, so the role used itself to get its own credentials
- the problem is that this is not possible in many cases where the 'assuming-profile' does not have the permission to assume itself
- changed it to use the original 'default' profile instead