### PR TITLE
Re-engineered AWS SSO accessToken expiry mechanism

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 log_cli = 1
 log_cli_level = INFO
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S
-addopts = --cov-config=.coveragerc --no-cov-on-fail --cov-report term-missing --cov=yawsso tests/
+log_cli_date_format = %Y-%m-%d %H:%M:%S
+addopts = --code-highlight=no --cov-config=.coveragerc --no-cov-on-fail --cov-report term-missing --cov=yawsso tests/


### PR DESCRIPTION
* Fixes #86 
* Fixes #90
* SSO cached session accessToken now expires in 1 hour after login, regardless.
  Hence, logic checking against `expiresAt` field is not effective anymore.
  Meantime, the IAM Identity Center (AWS SSO) offers sso-oidc protocol so that
  we can use refreshToken to exchange fresh accessToken as long as the sso login
  session lives.

[1] https://docs.aws.amazon.com/sdkref/latest/guide/understanding-sso.html
[2] https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sso-oidc/index.html
