### PR TITLE
Resolve auto login issue when refreshToken is missing

### DIFF
--- a/yawsso/core.py
+++ b/yawsso/core.py
@@ -88,19 +88,22 @@ def append_cli_global_options(cmd: str, profile: dict):
 
 
 def create_access_token(cached_login):
-    cmd_create_token = f"{aws_bin} sso-oidc create-token " \
-                       f"--output json " \
-                       f"--client-id {cached_login['clientId']} " \
-                       f"--client-secret {cached_login['clientSecret']} " \
-                       f"--grant-type refresh_token " \
-                       f"--refresh-token {cached_login['refreshToken']}"
+    if not cached_login.get('refreshToken'):
+        logger.log(TRACE, "refreshToken not found in cached login.")
+        return False, ""
+    else:
+        cmd_create_token = f"{aws_bin} sso-oidc create-token " \
+                           f"--output json " \
+                           f"--client-id {cached_login['clientId']} " \
+                           f"--client-secret {cached_login['clientSecret']} " \
+                           f"--grant-type refresh_token " \
+                           f"--refresh-token {cached_login['refreshToken']}"
+        create_token_success, create_token_output = u.invoke(cmd_create_token)
 
-    create_token_success, create_token_output = u.invoke(cmd_create_token)
+        if not create_token_success:
+            logger.log(TRACE, f"EXCEPTION: '{create_token_output}'")
 
-    if not create_token_success:
-        logger.log(TRACE, f"EXCEPTION: '{create_token_output}'")
-
-    return create_token_success, create_token_output
+        return create_token_success, create_token_output
 
 
 def get_role_credentials(profile_name, profile, access_token):


### PR DESCRIPTION
Hey Victor,

Firstly, thanks for providing this tool.

I was having this issue mentioned in issue #97.

I read the [create-token documentation](https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html) and if the `grant-type` is `refresh_token` then `refreshToken` is required. So I changed the code so that it doesn't attempt to create the token if `refreshToken` is not found in the cached login.

This avoids the KeyError exception.

I have tested this locally by running `make test` as well as changing the order of when the refreshToken is tried to before other methods and testing. This worked also.

![image](https://github.com/user-attachments/assets/44f3ba03-8de1-4187-974b-fc5f57aa3b3c)

Please let me know if you have any feedback. I didn't bump the release number as I can see you do that in another commit.

I also tried to match your code style as much as possible.

Thanks.